### PR TITLE
Create generic mapping for HKQuantityTypes

### DIFF
--- a/Sources/HealthKitOnOMH/HealthKit Extensions/HKQuantitySample.swift
+++ b/Sources/HealthKitOnOMH/HealthKit Extensions/HKQuantitySample.swift
@@ -1,0 +1,49 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import HealthKit
+
+
+extension HKQuantitySample {
+    func buildOMH() throws -> HkQuantitySample<Double> {
+        var unit = ""
+        switch self.quantityType {
+        case HKQuantityType(.heartRate):
+            unit = "count/min"
+        case HKQuantityType(.bloodGlucose):
+            unit = "mg/dL"
+        case HKQuantityType(.bodyMass):
+            unit = "kg"
+        case HKQuantityType(.bodyTemperature):
+            unit = "degC"
+        case HKQuantityType(.height):
+            unit = "m"
+        case HKQuantityType(.oxygenSaturation):
+            unit = "%"
+        case HKQuantityType(.respiratoryRate):
+            unit = "count/min"
+        case HKQuantityType(.stepCount):
+            unit = "count"
+        default:
+            throw HealthKitOnOMHError.notSupported
+        }
+
+        return HkQuantitySample<Double>(
+            quantityType: self.quantityType.identifier,
+            unitValue: UnitValue<Double>(unit: unit,
+                                         value: self.quantity.doubleValue(
+                                            for: HKUnit(from: unit)
+                                         )
+                                        ),
+            effectiveTimeFrame: TimeInterval(
+                startDateTime: self.startDate,
+                endDateTime: self.endDate
+            )
+        )
+    }
+}

--- a/Sources/HealthKitOnOMH/HealthKit Extensions/HKQuantitySample.swift
+++ b/Sources/HealthKitOnOMH/HealthKit Extensions/HKQuantitySample.swift
@@ -33,13 +33,11 @@ extension HKQuantitySample {
             throw HealthKitOnOMHError.notSupported
         }
 
+        let value = self.quantity.doubleValue(for: HKUnit(from: unit))
+
         return HkQuantitySample<Double>(
             quantityType: self.quantityType.identifier,
-            unitValue: UnitValue<Double>(unit: unit,
-                                         value: self.quantity.doubleValue(
-                                            for: HKUnit(from: unit)
-                                         )
-                                        ),
+            unitValue: UnitValue<Double>(unit: unit, value: value),
             effectiveTimeFrame: TimeInterval(
                 startDateTime: self.startDate,
                 endDateTime: self.endDate

--- a/Sources/HealthKitOnOMH/HealthKitOnOMHError.swift
+++ b/Sources/HealthKitOnOMH/HealthKitOnOMHError.swift
@@ -1,0 +1,13 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+/// Error thrown by the HealthKitOnOMH module if transforming a specific `HKSample` type to an OMH schema was not possible.
+enum HealthKitOnOMHError: Error {
+    /// Indicates that a specific `HKSample` type is currently not supported by HealthKitOnOMH.
+    case notSupported
+}

--- a/Sources/HealthKitOnOMH/Schemas/HkQuantitySample.swift
+++ b/Sources/HealthKitOnOMH/Schemas/HkQuantitySample.swift
@@ -1,0 +1,16 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import HealthKit
+
+/// A HealthKit Quantity Sample that represents data using a single numerical value and unit.
+struct HkQuantitySample<T>: Codable where T: Numeric, T: Codable {
+    let quantityType: String
+    let unitValue: UnitValue<T>
+    let effectiveTimeFrame: TimeInterval
+}

--- a/Sources/HealthKitOnOMH/Schemas/TimeInterval.swift
+++ b/Sources/HealthKitOnOMH/Schemas/TimeInterval.swift
@@ -1,0 +1,14 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+struct TimeInterval: Codable {
+    let startDateTime: Date
+    let endDateTime: Date
+}

--- a/Sources/HealthKitOnOMH/Schemas/UnitValue.swift
+++ b/Sources/HealthKitOnOMH/Schemas/UnitValue.swift
@@ -1,0 +1,14 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+/// Represents a numerical value with a unit of measure.
+/// Allowed units are drawn from HL7's UCUM (Unified Code for Units of Measure).
+struct UnitValue<T>: Codable where T: Numeric, T: Codable {
+    let unit: String
+    let value: T
+}

--- a/Tests/HealthKitOnOMHTests/HealthKitOnOMHTests.swift
+++ b/Tests/HealthKitOnOMHTests/HealthKitOnOMHTests.swift
@@ -6,9 +6,9 @@
 // SPDX-License-Identifier: MIT
 //
 
+import HealthKit
 @testable import HealthKitOnOMH
 import XCTest
-import HealthKit
 
 
 final class HealthKitOnOMHTests: XCTestCase {

--- a/Tests/HealthKitOnOMHTests/HealthKitOnOMHTests.swift
+++ b/Tests/HealthKitOnOMHTests/HealthKitOnOMHTests.swift
@@ -8,11 +8,34 @@
 
 @testable import HealthKitOnOMH
 import XCTest
+import HealthKit
 
 
 final class HealthKitOnOMHTests: XCTestCase {
-    func testHealthKitOnOMH() throws {
-        let healthKitOnOMH = HealthKitOnOMH()
-        XCTAssertEqual(healthKitOnOMH.stanford, "Stanford University")
+    var startDate: Date {
+        get throws {
+            let dateComponents = DateComponents(year: 1891, month: 10, day: 1, hour: 12, minute: 0, second: 0) // Date Stanford University opened (https://www.stanford.edu/about/history/)
+            return try XCTUnwrap(Calendar.current.date(from: dateComponents))
+        }
+    }
+
+    var endDate: Date {
+        get throws {
+            let dateComponents = DateComponents(year: 1891, month: 10, day: 1, hour: 12, minute: 0, second: 42)
+            return try XCTUnwrap(Calendar.current.date(from: dateComponents))
+        }
+    }
+
+    func testHeartRate() throws {
+        let heartRateSample = HKQuantitySample(
+            type: HKQuantityType(.heartRate),
+            quantity: HKQuantity(unit: .count().unitDivided(by: .minute()), doubleValue: 120),
+            start: try startDate,
+            end: try endDate
+        )
+
+        let omh = try heartRateSample.buildOMH()
+
+        XCTAssertEqual(120, omh.unitValue.value)
     }
 }


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Create generic mapping for HKQuantityTypes

## :bulb: Proposed solution
This PR creates a "catch-all" mapping for HKQuantityTypes to a [generic OMH schema](https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/granola_hk-quantity-sample).  Specific types will be mapped to corresponding OMH schemas in a forthcoming PR.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

