### PR TITLE
Adds metadata to OMH data points

### DIFF
--- a/Sources/HealthKitOnOMH/HealthKit Extensions/HKQuantitySample+OMH.swift
+++ b/Sources/HealthKitOnOMH/HealthKit Extensions/HKQuantitySample+OMH.swift
@@ -11,13 +11,35 @@ import OMHModels
 
 
 extension HKQuantitySample {
-    func buildOMHDataPoint() throws -> HealthKitQuantitySample<Double> {
+    func buildBloodGlucoseDataPoint() throws -> DataPoint<BloodGlucose> {
+        let body = BloodGlucose(
+            bloodGlucose: UnitValue<Double>(
+                unit: "mg/dL",
+                value: self.quantity.doubleValue(for: HKUnit(from: "mg/dL"))
+            ),
+            effectiveTimeFrame: TimeInterval(
+                startDateTime: self.startDate,
+                endDateTime: self.endDate
+            )
+        )
+
+        let header = Header(
+            id: self.uuid.uuidString,
+            creationDateTime: Date(),
+            schemaId: body.schemaId
+        )
+
+        return DataPoint<BloodGlucose>(
+            header: header,
+            body: body
+        )
+    }
+
+    func buildHKQuantityDataPoint() throws -> DataPoint<HealthKitQuantitySample<Double>> {
         var unit = ""
         switch self.quantityType {
         case HKQuantityType(.heartRate):
             unit = "count/min"
-        case HKQuantityType(.bloodGlucose):
-            unit = "mg/dL"
         case HKQuantityType(.bodyMass):
             unit = "kg"
         case HKQuantityType(.bodyTemperature):
@@ -36,13 +58,24 @@ extension HKQuantitySample {
 
         let value = self.quantity.doubleValue(for: HKUnit(from: unit))
 
-        return HealthKitQuantitySample<Double>(
+        let body = HealthKitQuantitySample<Double>(
             quantityType: self.quantityType.identifier,
             unitValue: UnitValue<Double>(unit: unit, value: value),
             effectiveTimeFrame: TimeInterval(
                 startDateTime: self.startDate,
                 endDateTime: self.endDate
             )
+        )
+
+        let header = Header(
+            id: self.uuid.uuidString,
+            creationDateTime: Date(),
+            schemaId: body.schemaId
+        )
+
+        return DataPoint<HealthKitQuantitySample>(
+            header: header,
+            body: body
         )
     }
 }

--- a/Sources/HealthKitOnOMH/HealthKit Extensions/HKQuantitySample+OMH.swift
+++ b/Sources/HealthKitOnOMH/HealthKit Extensions/HKQuantitySample+OMH.swift
@@ -11,6 +11,7 @@ import HealthKit
 
 
 extension HKQuantitySample {
+    /// The OMH data point created from converting this HKQuantitySample
     public var dataPoint: any DataPoint {
         get throws {
             let schema: any Schema

--- a/Sources/HealthKitOnOMH/HealthKit Extensions/SchemaDataPoint.swift
+++ b/Sources/HealthKitOnOMH/HealthKit Extensions/SchemaDataPoint.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 
 
-public enum Modality: String, Sendable, Codable {
-    case sensed = "sensed"
-    case selfReported = "self-reported"
+struct SchemaDataPoint<T: Schema & Sendable>: DataPoint {
+    var header: Header
+    var body: T
 }

--- a/Sources/HealthKitOnOMH/HealthKitOnOMHError.swift
+++ b/Sources/HealthKitOnOMH/HealthKitOnOMHError.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+
 /// Error thrown by the HealthKitOnOMH module if transforming a specific `HKSample` type to an OMH schema was not possible.
 enum HealthKitOnOMHError: Error {
     /// Indicates that a specific `HKSample` type is currently not supported by HealthKitOnOMH.

--- a/Sources/OMHModels/AcquisitionProvenance.swift
+++ b/Sources/OMHModels/AcquisitionProvenance.swift
@@ -5,11 +5,22 @@
 //
 // SPDX-License-Identifier: MIT
 
-
 import Foundation
 
-open class AcquisitionProvenance: Codable {
+
+public struct AcquisitionProvenance: Sendable, Codable {
     public var sourceName: String
     public var sourceCreationDateTime: Date?
     public var modality: Modality?
+    
+    
+    init(
+        sourceName: String,
+        sourceCreationDateTime: Date? = nil,
+        modality: Modality? = nil
+    ) {
+        self.sourceName = sourceName
+        self.sourceCreationDateTime = sourceCreationDateTime
+        self.modality = modality
+    }
 }

--- a/Sources/OMHModels/AcquisitionProvenance.swift
+++ b/Sources/OMHModels/AcquisitionProvenance.swift
@@ -8,9 +8,18 @@
 import Foundation
 
 
+/// Metadata representing the source of a data point
 public struct AcquisitionProvenance: Sendable, Codable {
+    /// The name of the source of the data.
     public var sourceName: String
+
+    /// The date time (timestamp) of data creation at the source.
     public var sourceCreationDateTime: Date?
+
+    /// The date time (timestamp) of last data modification at the source.
+    public var sourceLastModificationDateTime: Date?
+
+    /// The `Modality` whereby the measure is obtained.
     public var modality: Modality?
     
     

--- a/Sources/OMHModels/AcquisitionProvenance.swift
+++ b/Sources/OMHModels/AcquisitionProvenance.swift
@@ -1,0 +1,15 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+
+import Foundation
+
+open class AcquisitionProvenance: Codable {
+    public var sourceName: String
+    public var sourceCreationDateTime: Date?
+    public var modality: Modality?
+}

--- a/Sources/OMHModels/BloodGlucose.swift
+++ b/Sources/OMHModels/BloodGlucose.swift
@@ -5,24 +5,20 @@
 //
 // SPDX-License-Identifier: MIT
 
-open class BloodGlucose: Schema {
-    private enum CodingKeys: String, CodingKey {
-        case bloodGlucose
-        case effectiveTimeFrame
-        case specimenSource
-        case temporalRelationshipToMeal
-        case temporalRelationshipToSleep
-        case descriptiveStatistic
-    }
 
+public struct BloodGlucose: Schema {
+    public static let schemaId = SchemaId(namespace: .omh, name: "blood-glucose", version: "3.0")
+    
+    
     public var bloodGlucose: UnitValue<Double>
     public var effectiveTimeFrame: TimeInterval
     public var specimenSource: SpecimenSource?
     public var temporalRelationshipToMeal: TemporalRelationshipToMeal?
     public var temporalRelationshipToSleep: TemporalRelationshipToSleep?
     public var descriptiveStatistic: DescriptiveStatistic?
-
-    public required init (
+    
+    
+    public init (
         bloodGlucose: UnitValue<Double>,
         effectiveTimeFrame: TimeInterval,
         specimenSource: SpecimenSource? = nil,
@@ -36,47 +32,5 @@ open class BloodGlucose: Schema {
         self.temporalRelationshipToMeal = temporalRelationshipToMeal
         self.temporalRelationshipToSleep = temporalRelationshipToSleep
         self.descriptiveStatistic = descriptiveStatistic
-        super.init(schemaId: SchemaId(namespace: .omh, name: "blood-glucose", version: "3.0"))
-    }
-
-    public required init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        self.bloodGlucose = try container.decode(
-            UnitValue<Double>.self,
-            forKey: .bloodGlucose
-        )
-        self.effectiveTimeFrame = try container.decode(
-            TimeInterval.self,
-            forKey: .effectiveTimeFrame
-        )
-        self.specimenSource = try container.decode(
-            SpecimenSource.self,
-            forKey: .specimenSource
-        )
-        self.temporalRelationshipToMeal = try container.decodeIfPresent(
-            TemporalRelationshipToMeal.self,
-            forKey: .temporalRelationshipToMeal
-        )
-        self.temporalRelationshipToSleep = try container.decodeIfPresent(
-            TemporalRelationshipToSleep.self,
-            forKey: .temporalRelationshipToSleep
-        )
-        self.descriptiveStatistic = try container.decodeIfPresent(
-            DescriptiveStatistic.self,
-            forKey: .descriptiveStatistic
-        )
-        super.init(schemaId: SchemaId(namespace: .omh, name: "blood-glucose", version: "3.0"))
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-
-        try container.encode(bloodGlucose, forKey: .bloodGlucose)
-        try container.encode(effectiveTimeFrame, forKey: .effectiveTimeFrame)
-        try container.encodeIfPresent(specimenSource, forKey: .specimenSource)
-        try container.encodeIfPresent(temporalRelationshipToMeal, forKey: .temporalRelationshipToMeal)
-        try container.encodeIfPresent(temporalRelationshipToSleep, forKey: .temporalRelationshipToSleep)
-        try container.encodeIfPresent(descriptiveStatistic, forKey: .descriptiveStatistic)
     }
 }

--- a/Sources/OMHModels/BloodGlucose.swift
+++ b/Sources/OMHModels/BloodGlucose.swift
@@ -5,7 +5,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-open class BloodGlucose: OMHSchema {
+open class BloodGlucose: Schema {
     private enum CodingKeys: String, CodingKey {
         case bloodGlucose
         case effectiveTimeFrame
@@ -15,7 +15,6 @@ open class BloodGlucose: OMHSchema {
         case descriptiveStatistic
     }
 
-    public var schemaId = SchemaId(namespace: .omh, name: "blood-glucose", version: "3.0")
     public var bloodGlucose: UnitValue<Double>
     public var effectiveTimeFrame: TimeInterval
     public var specimenSource: SpecimenSource?
@@ -37,6 +36,7 @@ open class BloodGlucose: OMHSchema {
         self.temporalRelationshipToMeal = temporalRelationshipToMeal
         self.temporalRelationshipToSleep = temporalRelationshipToSleep
         self.descriptiveStatistic = descriptiveStatistic
+        super.init(schemaId: SchemaId(namespace: .omh, name: "blood-glucose", version: "3.0"))
     }
 
     public required init(from decoder: Decoder) throws {
@@ -66,6 +66,7 @@ open class BloodGlucose: OMHSchema {
             DescriptiveStatistic.self,
             forKey: .descriptiveStatistic
         )
+        super.init(schemaId: SchemaId(namespace: .omh, name: "blood-glucose", version: "3.0"))
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/Sources/OMHModels/BloodGlucose.swift
+++ b/Sources/OMHModels/BloodGlucose.swift
@@ -5,7 +5,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-open class BloodGlucose: Codable {
+open class BloodGlucose: OMHSchema {
     private enum CodingKeys: String, CodingKey {
         case bloodGlucose
         case effectiveTimeFrame
@@ -15,6 +15,7 @@ open class BloodGlucose: Codable {
         case descriptiveStatistic
     }
 
+    public var schemaId = SchemaId(namespace: .omh, name: "blood-glucose", version: "3.0")
     public var bloodGlucose: UnitValue<Double>
     public var effectiveTimeFrame: TimeInterval
     public var specimenSource: SpecimenSource?

--- a/Sources/OMHModels/BloodGlucose.swift
+++ b/Sources/OMHModels/BloodGlucose.swift
@@ -5,16 +5,29 @@
 //
 // SPDX-License-Identifier: MIT
 
-
+/// A Blood Glucose's measurement
+/// Generated from Open mHealth `omh:blood-glucose:30` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_blood-glucose)
 public struct BloodGlucose: Schema {
+    /// The Open mHealth schema identifier
     public static let schemaId = SchemaId(namespace: .omh, name: "blood-glucose", version: "3.0")
     
-    
+    /// The blood glucose measurement as a `UnitValue` containing a double value and a unit
     public var bloodGlucose: UnitValue<Double>
+
+    /// The time interval corresponding to this measurement
     public var effectiveTimeFrame: TimeInterval
+
+    /// The type of specimen this measurement was made on (e.g. capillary blood)
     public var specimenSource: SpecimenSource?
+
+    /// The relationship of this measurement to meals (e.g. before breakfast)
     public var temporalRelationshipToMeal: TemporalRelationshipToMeal?
+
+    /// The relationship of this measurement to sleep (e.g. on waking)
     public var temporalRelationshipToSleep: TemporalRelationshipToSleep?
+
+    /// If the value in this data point is a descriptive statistic rather than a single measurement (e.g. minimum, average, median)
+    /// this property should contain the specific type of descriptive statistic
     public var descriptiveStatistic: DescriptiveStatistic?
     
     

--- a/Sources/OMHModels/DataPoint.swift
+++ b/Sources/OMHModels/DataPoint.swift
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: MIT
 
 
+/// A protocol for an Open mHealth data point container
+/// Generated from Open mHealth `omh:data-point:1.0` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_data-point)
 public protocol DataPoint<Body>: Sendable {
     associatedtype Body: Schema
     

--- a/Sources/OMHModels/DataPoint.swift
+++ b/Sources/OMHModels/DataPoint.swift
@@ -6,15 +6,10 @@
 // SPDX-License-Identifier: MIT
 
 
-open class DataPoint<T: Schema> {
-    public var header: Header
-    public var body: T
-
-    public init (
-        header: Header,
-        body: T
-    ) {
-        self.header = header
-        self.body = body
-    }
+public protocol DataPoint<Body>: Sendable {
+    associatedtype Body: Schema
+    
+    
+    var header: Header { get }
+    var body: Body { get set }
 }

--- a/Sources/OMHModels/DataPoint.swift
+++ b/Sources/OMHModels/DataPoint.swift
@@ -1,0 +1,12 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+
+open class DataPoint<T: OMHSchema>: Codable {
+    public var header: Header
+    public var body: T
+}

--- a/Sources/OMHModels/DataPoint.swift
+++ b/Sources/OMHModels/DataPoint.swift
@@ -6,7 +6,15 @@
 // SPDX-License-Identifier: MIT
 
 
-open class DataPoint<T: OMHSchema>: Codable {
+open class DataPoint<T: Schema> {
     public var header: Header
     public var body: T
+
+    public init (
+        header: Header,
+        body: T
+    ) {
+        self.header = header
+        self.body = body
+    }
 }

--- a/Sources/OMHModels/DescriptiveStatistic.swift
+++ b/Sources/OMHModels/DescriptiveStatistic.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 
 
+/// An enumeration representing different types of stastical measures that can be represented in data points
 public enum DescriptiveStatistic: String, Codable {
     case average = "average"
     case count = "count"

--- a/Sources/OMHModels/Header.swift
+++ b/Sources/OMHModels/Header.swift
@@ -7,23 +7,36 @@
 
 import Foundation
 
-
+/// This schema represents the header of a data point.
+/// Generated from Open mHealth omh:header:1.2 (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_header)
 public struct Header: Codable, Sendable {
+    /// The identifier of this data point - should be a globally unique value.
     public var id: String
+
+    /// The date time this data point was created on the system where data is stored.
     public var creationDateTime: Date
+
+    /// The schema identifier of the body of the data point.
     public var schemaId: SchemaId
+
+    /// An `AcquisitionProvenance` provides metadata regarding the origin of the data
     public var acquisitionProvenance: AcquisitionProvenance?
-    
+
+    /// The user this data point belongs to.
+    public var userId: String?
+
     
     public init (
         id: String,
         creationDateTime: Date,
         schemaId: SchemaId,
-        acquisitionProvenance: AcquisitionProvenance? = nil
+        acquisitionProvenance: AcquisitionProvenance? = nil,
+        userId: String? = nil
     ) {
         self.id = id
         self.creationDateTime = creationDateTime
         self.schemaId = schemaId
         self.acquisitionProvenance = acquisitionProvenance
+        self.userId = userId
     }
 }

--- a/Sources/OMHModels/Header.swift
+++ b/Sources/OMHModels/Header.swift
@@ -1,0 +1,16 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+
+import Foundation
+
+open class Header: Codable {
+    public var id: String
+    public var creationDateTime: Date
+    public var schemaId: SchemaId
+    public var acquisitionProvenance: String?
+}

--- a/Sources/OMHModels/Header.swift
+++ b/Sources/OMHModels/Header.swift
@@ -12,5 +12,17 @@ open class Header: Codable {
     public var id: String
     public var creationDateTime: Date
     public var schemaId: SchemaId
-    public var acquisitionProvenance: String?
+    public var acquisitionProvenance: AcquisitionProvenance?
+
+    public init (
+        id: String,
+        creationDateTime: Date,
+        schemaId: SchemaId,
+        acquisitionProvenance: AcquisitionProvenance? = nil
+    ) {
+        self.id = id
+        self.creationDateTime = creationDateTime
+        self.schemaId = schemaId
+        self.acquisitionProvenance = acquisitionProvenance
+    }
 }

--- a/Sources/OMHModels/Header.swift
+++ b/Sources/OMHModels/Header.swift
@@ -5,15 +5,16 @@
 //
 // SPDX-License-Identifier: MIT
 
-
 import Foundation
 
-open class Header: Codable {
+
+public struct Header: Codable, Sendable {
     public var id: String
     public var creationDateTime: Date
     public var schemaId: SchemaId
     public var acquisitionProvenance: AcquisitionProvenance?
-
+    
+    
     public init (
         id: String,
         creationDateTime: Date,

--- a/Sources/OMHModels/HealthKitQuantitySample.swift
+++ b/Sources/OMHModels/HealthKitQuantitySample.swift
@@ -8,14 +8,20 @@
 
 
 /// A HealthKit Quantity Sample that represents data using a single numerical value and unit.
+/// Generated from Open mHealth `granola:hk-quantity-sample:1.0` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/granola_hk-quantity-sample)
 public struct HealthKitQuantitySample<T>: Schema where T: Numeric & Codable {
+    /// An Open mHealth schema identifier
     public static var schemaId: SchemaId {
         SchemaId(namespace: .granola, name: "hk-quantity-sample", version: "1.0")
     }
     
-    
+    /// A string representation of the HKQuantityType
     public var quantityType: String
+
+    /// The associated UnitValue for this HealthKitQuantitySample
     public var unitValue: UnitValue<T>
+
+    /// The associated TimeInterval for this HealthKitQuantitySample
     public var effectiveTimeFrame: TimeInterval
     
     

--- a/Sources/OMHModels/HealthKitQuantitySample.swift
+++ b/Sources/OMHModels/HealthKitQuantitySample.swift
@@ -9,7 +9,7 @@
 
 /// A HealthKit Quantity Sample that represents data using a single numerical value and unit.
 public struct HealthKitQuantitySample<T>: Schema where T: Numeric & Codable {
-    static public var schemaId: SchemaId {
+    public static var schemaId: SchemaId {
         SchemaId(namespace: .granola, name: "hk-quantity-sample", version: "1.0")
     }
     

--- a/Sources/OMHModels/HealthKitQuantitySample.swift
+++ b/Sources/OMHModels/HealthKitQuantitySample.swift
@@ -10,7 +10,7 @@
 /// A HealthKit Quantity Sample that represents data using a single numerical value and unit.
 public struct HealthKitQuantitySample<T>: Schema where T: Numeric & Codable {
     static public var schemaId: SchemaId {
-        SchemaId(namespace: .omh, name: "HealthKitQuantitySample<\(String(describing: T.self))>", version: "2.0")
+        SchemaId(namespace: .granola, name: "hk-quantity-sample", version: "1.0")
     }
     
     

--- a/Sources/OMHModels/HealthKitQuantitySample.swift
+++ b/Sources/OMHModels/HealthKitQuantitySample.swift
@@ -9,8 +9,7 @@
 import HealthKit
 
 /// A HealthKit Quantity Sample that represents data using a single numerical value and unit.
-open class HealthKitQuantitySample<T>: OMHSchema where T: Numeric, T: Codable {
-    public var schemaId = SchemaId(namespace: .omh, name: "heart-rate", version: "2.0")
+open class HealthKitQuantitySample<T>: Schema where T: Numeric, T: Codable {
     public var quantityType: String
     public var unitValue: UnitValue<T>
     public var effectiveTimeFrame: TimeInterval
@@ -23,5 +22,6 @@ open class HealthKitQuantitySample<T>: OMHSchema where T: Numeric, T: Codable {
         self.quantityType = quantityType
         self.unitValue = unitValue
         self.effectiveTimeFrame = effectiveTimeFrame
+        super.init(schemaId: SchemaId(namespace: .omh, name: "heart-rate", version: "2.0"))
     }
 }

--- a/Sources/OMHModels/HealthKitQuantitySample.swift
+++ b/Sources/OMHModels/HealthKitQuantitySample.swift
@@ -6,14 +6,19 @@
 // SPDX-License-Identifier: MIT
 //
 
-import HealthKit
 
 /// A HealthKit Quantity Sample that represents data using a single numerical value and unit.
-open class HealthKitQuantitySample<T>: Schema where T: Numeric, T: Codable {
+public struct HealthKitQuantitySample<T>: Schema where T: Numeric & Codable {
+    static public var schemaId: SchemaId {
+        SchemaId(namespace: .omh, name: "HealthKitQuantitySample<\(String(describing: T.self))>", version: "2.0")
+    }
+    
+    
     public var quantityType: String
     public var unitValue: UnitValue<T>
     public var effectiveTimeFrame: TimeInterval
-
+    
+    
     public init (
         quantityType: String,
         unitValue: UnitValue<T>,
@@ -22,6 +27,5 @@ open class HealthKitQuantitySample<T>: Schema where T: Numeric, T: Codable {
         self.quantityType = quantityType
         self.unitValue = unitValue
         self.effectiveTimeFrame = effectiveTimeFrame
-        super.init(schemaId: SchemaId(namespace: .omh, name: "heart-rate", version: "2.0"))
     }
 }

--- a/Sources/OMHModels/HealthKitQuantitySample.swift
+++ b/Sources/OMHModels/HealthKitQuantitySample.swift
@@ -9,7 +9,8 @@
 import HealthKit
 
 /// A HealthKit Quantity Sample that represents data using a single numerical value and unit.
-open class HealthKitQuantitySample<T>: Codable where T: Numeric, T: Codable {
+open class HealthKitQuantitySample<T>: OMHSchema where T: Numeric, T: Codable {
+    public var schemaId = SchemaId(namespace: .omh, name: "heart-rate", version: "2.0")
     public var quantityType: String
     public var unitValue: UnitValue<T>
     public var effectiveTimeFrame: TimeInterval

--- a/Sources/OMHModels/Modality.swift
+++ b/Sources/OMHModels/Modality.swift
@@ -1,0 +1,12 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+
+public enum Modality: String, Codable {
+    case sensed = "sensed"
+    case selfReported = "self-reported"
+}

--- a/Sources/OMHModels/Modality.swift
+++ b/Sources/OMHModels/Modality.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 
 
+/// The modality whereby the measure is obtained.
 public enum Modality: String, Sendable, Codable {
     case sensed = "sensed"
     case selfReported = "self-reported"

--- a/Sources/OMHModels/OMHSchema.swift
+++ b/Sources/OMHModels/OMHSchema.swift
@@ -1,0 +1,11 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+
+public protocol OMHSchema: Codable {
+    var schemaId: SchemaId { get }
+}

--- a/Sources/OMHModels/Schema.swift
+++ b/Sources/OMHModels/Schema.swift
@@ -6,6 +6,10 @@
 // SPDX-License-Identifier: MIT
 
 
-public protocol OMHSchema: Codable {
-    var schemaId: SchemaId { get }
+open class Schema {
+    public var schemaId: SchemaId
+
+    public init(schemaId: SchemaId) {
+        self.schemaId = schemaId
+    }
 }

--- a/Sources/OMHModels/Schema.swift
+++ b/Sources/OMHModels/Schema.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 
 
+/// A protocol for an Open mHealth schema
 public protocol Schema: Codable {
     static var schemaId: SchemaId { get }
 }

--- a/Sources/OMHModels/Schema.swift
+++ b/Sources/OMHModels/Schema.swift
@@ -6,10 +6,6 @@
 // SPDX-License-Identifier: MIT
 
 
-open class Schema {
-    public var schemaId: SchemaId
-
-    public init(schemaId: SchemaId) {
-        self.schemaId = schemaId
-    }
+public protocol Schema: Codable {
+    static var schemaId: SchemaId { get }
 }

--- a/Sources/OMHModels/SchemaId.swift
+++ b/Sources/OMHModels/SchemaId.swift
@@ -6,13 +6,17 @@
 // SPDX-License-Identifier: MIT
 
 
-open class SchemaId: Codable {
+public struct SchemaId: Sendable, Codable {
     public var namespace: SchemaNamespace
     public var name: String
     public var version: String
-
-    public var description: String { "\(namespace.rawValue):\(name):\(version))" }
-
+    
+    
+    public var description: String {
+        "\(namespace.rawValue):\(name):\(version))"
+    }
+    
+    
     public init (
         namespace: SchemaNamespace,
         name: String,

--- a/Sources/OMHModels/SchemaId.swift
+++ b/Sources/OMHModels/SchemaId.swift
@@ -4,12 +4,23 @@
 // SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
+import Foundation
 
 
+/// A schema identifier for an Open mHealth schema
+/// Generated from Open mHealth `omh:schema-id:1.1` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_schema-id)
 public struct SchemaId: Sendable, Codable, CustomStringConvertible {
+    /// The namespace of the schema. A namespace serves to disambiguate schemas with conflicting names.
     public var namespace: SchemaNamespace
+
+    /// The name of the schema.
     public var name: String
+
+    /// The version of the schema.
     public var version: String
+
+    /// A URL to retrieve the schema. If a URL is not specified, it is assumed that the schema can be located using other means.
+    public var url: URL?
     
     
     public var description: String {

--- a/Sources/OMHModels/SchemaId.swift
+++ b/Sources/OMHModels/SchemaId.swift
@@ -1,0 +1,27 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+
+open class SchemaId: Codable {
+    public var namespace: SchemaNamespace
+    public var name: String
+    public var version: String
+
+    public var description: String {
+        return "\(namespace.rawValue):\(name):\(version))"
+    }
+
+    public init (
+        namespace: SchemaNamespace,
+        name: String,
+        version: String
+    ) {
+        self.namespace = namespace
+        self.name = name
+        self.version = version
+    }
+}

--- a/Sources/OMHModels/SchemaId.swift
+++ b/Sources/OMHModels/SchemaId.swift
@@ -11,9 +11,7 @@ open class SchemaId: Codable {
     public var name: String
     public var version: String
 
-    public var description: String {
-        return "\(namespace.rawValue):\(name):\(version))"
-    }
+    public var description: String { "\(namespace.rawValue):\(name):\(version))" }
 
     public init (
         namespace: SchemaNamespace,

--- a/Sources/OMHModels/SchemaId.swift
+++ b/Sources/OMHModels/SchemaId.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 
 
-public struct SchemaId: Sendable, Codable {
+public struct SchemaId: Sendable, Codable, CustomStringConvertible {
     public var namespace: SchemaNamespace
     public var name: String
     public var version: String

--- a/Sources/OMHModels/SchemaNamespace.swift
+++ b/Sources/OMHModels/SchemaNamespace.swift
@@ -1,0 +1,12 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+
+public enum SchemaNamespace: String, Codable {
+    case ieee
+    case omh
+}

--- a/Sources/OMHModels/SchemaNamespace.swift
+++ b/Sources/OMHModels/SchemaNamespace.swift
@@ -9,4 +9,5 @@
 public enum SchemaNamespace: String, Sendable, Codable {
     case ieee
     case omh
+    case granola
 }

--- a/Sources/OMHModels/SchemaNamespace.swift
+++ b/Sources/OMHModels/SchemaNamespace.swift
@@ -5,7 +5,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-
+/// The namespace of a schema, which serves to disambiguate schemas with conflicting names.
 public enum SchemaNamespace: String, Sendable, Codable {
     case ieee
     case omh

--- a/Sources/OMHModels/SchemaNamespace.swift
+++ b/Sources/OMHModels/SchemaNamespace.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 
 
-public enum SchemaNamespace: String, Codable {
+public enum SchemaNamespace: String, Sendable, Codable {
     case ieee
     case omh
 }

--- a/Sources/OMHModels/SpecimenSource.swift
+++ b/Sources/OMHModels/SpecimenSource.swift
@@ -5,7 +5,9 @@
 //
 // SPDX-License-Identifier: MIT
 
-
+/// The set of allowable values describing the source of a specimen analyzed.
+/// The value set is not complete. More values are added as use cases require.
+/// Generated from Open mHealth `omh:specimen-source:2.1` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_specimen-source)
 public enum SpecimenSource: String, Codable {
     case breath = "breath"
     case capillaryBlood = "capillary blood"

--- a/Sources/OMHModels/SpecimenSource.swift
+++ b/Sources/OMHModels/SpecimenSource.swift
@@ -5,6 +5,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+
 public enum SpecimenSource: String, Codable {
     case breath = "breath"
     case capillaryBlood = "capillary blood"

--- a/Sources/OMHModels/TemporalRelationshipToMeal.swift
+++ b/Sources/OMHModels/TemporalRelationshipToMeal.swift
@@ -7,7 +7,8 @@
 //
 
 
-/// Represents the temporal relationship of a clinical measure or assessment to meals
+/// Represents the temporal relationship of a clinical measure or assessment to meals (e.g., fasting, after lunch).
+/// Generated from Open mHealth `omh:temporal-relationship-to-meal:1.2` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_temporal-relationship-to-meal)
 public enum TemporalRelationshipToMeal: String, Codable {
     case fasting = "fasting"
     case notFasting = "not fasting"

--- a/Sources/OMHModels/TemporalRelationshipToPhysicalActivity.swift
+++ b/Sources/OMHModels/TemporalRelationshipToPhysicalActivity.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+
 /// Represents the temporal relationship of a clinical measure or assessment to physical activity.
 public enum TemporalRelationshipToPhysicalActivity: String, Codable {
     case atRest = "at rest"

--- a/Sources/OMHModels/TemporalRelationshipToPhysicalActivity.swift
+++ b/Sources/OMHModels/TemporalRelationshipToPhysicalActivity.swift
@@ -7,7 +7,8 @@
 //
 
 
-/// Represents the temporal relationship of a clinical measure or assessment to physical activity.
+/// This schema represents the temporal relationship of a clinical measure or assessment to physical activity (e.g., at rest, during exercise).
+/// Generated from Open mHealth `omh:temporal-relationship-to-physical-activity:1.0` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_temporal-relationship-to-physical-activity)
 public enum TemporalRelationshipToPhysicalActivity: String, Codable {
     case atRest = "at rest"
     case active = "active"

--- a/Sources/OMHModels/TemporalRelationshipToSleep.swift
+++ b/Sources/OMHModels/TemporalRelationshipToSleep.swift
@@ -8,6 +8,7 @@
 
 
 /// Represents the temporal relationship of a clinical measure or assessment to sleep
+/// Generated from Open mHealth `omh:temporal-relationship-to-sleep:1.0` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_temporal-relationship-to-sleep)
 public enum TemporalRelationshipToSleep: String, Codable {
     case beforeSleeping = "before sleeping"
     case duringSleep = "during sleep"

--- a/Sources/OMHModels/TimeInterval.swift
+++ b/Sources/OMHModels/TimeInterval.swift
@@ -8,9 +8,13 @@
 
 import Foundation
 
-/// An interval of time with a specified start and end time
+/// This schema describes an interval of time.
+/// Generated from Open mHealth `omh:time-interval:1.0` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_time-interval)
 public struct TimeInterval: Codable {
+    /// The start timestamp of this interval
     public var startDateTime: Date
+
+    /// The end timestamp of this interval
     public var endDateTime: Date
     
     

--- a/Sources/OMHModels/TimeInterval.swift
+++ b/Sources/OMHModels/TimeInterval.swift
@@ -8,10 +8,12 @@
 
 import Foundation
 
-open class TimeInterval: Codable {
+
+public struct TimeInterval: Codable {
     public var startDateTime: Date
     public var endDateTime: Date
-
+    
+    
     public init (
         startDateTime: Date,
         endDateTime: Date

--- a/Sources/OMHModels/TimeInterval.swift
+++ b/Sources/OMHModels/TimeInterval.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-
+/// An interval of time with a specified start and end time
 public struct TimeInterval: Codable {
     public var startDateTime: Date
     public var endDateTime: Date

--- a/Sources/OMHModels/UnitValue.swift
+++ b/Sources/OMHModels/UnitValue.swift
@@ -8,9 +8,12 @@
 
 
 /// Represents a numerical value with a unit of measure.
-/// Allowed units are drawn from HL7's UCUM (Unified Code for Units of Measure).
+/// Generated from Open mHealth `omh:unit-value:1.0` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_unit-value)
 public struct UnitValue<T>: Codable where T: Numeric & Codable {
+    /// String representing a unit drawn from UCUM (Unified Code for Units of Measure).
     public var unit: String
+
+    /// A numeric value
     public var value: T
     
     

--- a/Sources/OMHModels/UnitValue.swift
+++ b/Sources/OMHModels/UnitValue.swift
@@ -6,12 +6,14 @@
 // SPDX-License-Identifier: MIT
 //
 
+
 /// Represents a numerical value with a unit of measure.
 /// Allowed units are drawn from HL7's UCUM (Unified Code for Units of Measure).
-open class UnitValue<T>: Codable where T: Numeric, T: Codable {
+public struct UnitValue<T>: Codable where T: Numeric & Codable {
     public var unit: String
     public var value: T
-
+    
+    
     public init(
         unit: String,
         value: T

--- a/Tests/HealthKitOnOMHTests/HealthKitOnOMHTests.swift
+++ b/Tests/HealthKitOnOMHTests/HealthKitOnOMHTests.swift
@@ -18,14 +18,14 @@ final class HealthKitOnOMHTests: XCTestCase {
             return try XCTUnwrap(Calendar.current.date(from: dateComponents))
         }
     }
-
+    
     var endDate: Date {
         get throws {
             let dateComponents = DateComponents(year: 1891, month: 10, day: 1, hour: 12, minute: 0, second: 42)
             return try XCTUnwrap(Calendar.current.date(from: dateComponents))
         }
     }
-
+    
     func testHeartRate() throws {
         let heartRateSample = HKQuantitySample(
             type: HKQuantityType(.heartRate),
@@ -33,13 +33,13 @@ final class HealthKitOnOMHTests: XCTestCase {
             start: try startDate,
             end: try endDate
         )
-
-        let omhDataPoint = try heartRateSample.buildHKQuantityDataPoint()
-
+        
+        let omhDataPoint = try XCTUnwrap(heartRateSample.dataPoint as? any DataPoint<HealthKitQuantitySample<Double>>)
+        
         XCTAssertEqual(120, omhDataPoint.body.unitValue.value)
         XCTAssertEqual("count/min", omhDataPoint.body.unitValue.unit)
     }
-
+    
     func testBloodGlucose() throws {
         let bloodGlucoseSample = HKQuantitySample(
             type: HKQuantityType(.bloodGlucose),
@@ -48,9 +48,9 @@ final class HealthKitOnOMHTests: XCTestCase {
             end: try endDate,
             metadata: [HKMetadataKeyBloodGlucoseMealTime: 1]
         )
-
-        let omhDataPoint = try bloodGlucoseSample.buildBloodGlucoseDataPoint()
-
+        
+        let omhDataPoint = try XCTUnwrap(bloodGlucoseSample.dataPoint as? any DataPoint<BloodGlucose>)
+        
         XCTAssertEqual(90, omhDataPoint.body.bloodGlucose.value)
         XCTAssertEqual("mg/dL", omhDataPoint.body.bloodGlucose.unit)
     }

--- a/Tests/HealthKitOnOMHTests/HealthKitOnOMHTests.swift
+++ b/Tests/HealthKitOnOMHTests/HealthKitOnOMHTests.swift
@@ -34,10 +34,10 @@ final class HealthKitOnOMHTests: XCTestCase {
             end: try endDate
         )
 
-        let omh = try heartRateSample.buildOMHDataPoint()
+        let omhDataPoint = try heartRateSample.buildHKQuantityDataPoint()
 
-        XCTAssertEqual(120, omh.unitValue.value)
-        XCTAssertEqual("count/min", omh.unitValue.unit)
+        XCTAssertEqual(120, omhDataPoint.body.unitValue.value)
+        XCTAssertEqual("count/min", omhDataPoint.body.unitValue.unit)
     }
 
     func testBloodGlucose() throws {
@@ -49,9 +49,9 @@ final class HealthKitOnOMHTests: XCTestCase {
             metadata: [HKMetadataKeyBloodGlucoseMealTime: 1]
         )
 
-        let omh = try bloodGlucoseSample.buildOMHDataPoint()
+        let omhDataPoint = try bloodGlucoseSample.buildBloodGlucoseDataPoint()
 
-        XCTAssertEqual(90, omh.unitValue.value)
-        XCTAssertEqual("mg/dL", omh.unitValue.unit)
+        XCTAssertEqual(90, omhDataPoint.body.bloodGlucose.value)
+        XCTAssertEqual("mg/dL", omhDataPoint.body.bloodGlucose.unit)
     }
 }

--- a/Tests/HealthKitOnOMHTests/OMHModelsTests.swift
+++ b/Tests/HealthKitOnOMHTests/OMHModelsTests.swift
@@ -9,6 +9,7 @@
 @testable import OMHModels
 import XCTest
 
+
 final class OMHModelsTests: XCTestCase {
     var startDate: Date {
         get throws {
@@ -16,14 +17,14 @@ final class OMHModelsTests: XCTestCase {
             return try XCTUnwrap(Calendar.current.date(from: dateComponents))
         }
     }
-
+    
     var endDate: Date {
         get throws {
             let dateComponents = DateComponents(year: 1891, month: 10, day: 1, hour: 12, minute: 0, second: 42)
             return try XCTUnwrap(Calendar.current.date(from: dateComponents))
         }
     }
-
+    
     func testBloodGlucose() throws {
         let beforeBreakfastGlucose = BloodGlucose(
             bloodGlucose: UnitValue(unit: "mg/dL", value: 80),
@@ -31,26 +32,26 @@ final class OMHModelsTests: XCTestCase {
             specimenSource: SpecimenSource.capillaryBlood,
             temporalRelationshipToMeal: TemporalRelationshipToMeal.beforeBreakfast
         )
-
+        
         XCTAssertEqual(80, beforeBreakfastGlucose.bloodGlucose.value)
         XCTAssertEqual(beforeBreakfastGlucose.temporalRelationshipToMeal, TemporalRelationshipToMeal.beforeBreakfast)
         XCTAssertEqual(beforeBreakfastGlucose.specimenSource, SpecimenSource.capillaryBlood)
-
+        
         let duringSleepBloodGlucose = BloodGlucose(
             bloodGlucose: UnitValue(unit: "mg/dL", value: 70),
             effectiveTimeFrame: TimeInterval(startDateTime: try startDate, endDateTime: try endDate),
             specimenSource: SpecimenSource.capillaryBlood,
             temporalRelationshipToSleep: TemporalRelationshipToSleep.duringSleep
         )
-
+        
         XCTAssertEqual(duringSleepBloodGlucose.temporalRelationshipToSleep, TemporalRelationshipToSleep.duringSleep)
-
+        
         let averageBloodGlucose = BloodGlucose(
             bloodGlucose: UnitValue(unit: "mg/dL", value: 120),
             effectiveTimeFrame: TimeInterval(startDateTime: try startDate, endDateTime: try endDate),
             descriptiveStatistic: DescriptiveStatistic.average
         )
-
+        
         XCTAssertEqual(averageBloodGlucose.descriptiveStatistic, DescriptiveStatistic.average)
     }
 }


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford Biodesign for Digital Health and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Adds metadata to OMH data points

## :bulb: Proposed solution
An Open mHealth data point contains a [header](https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_header) and a body. The header contains metadata such as the id, schema version, and acquisition provenance. The body contains the data itself, represented according to the appropriate OMH data schema (e.g. heart-rate, blood-glucose). In this PR, we create the types necessary to construct OMH data points with this header + body structure, including types to represent the associated metadata. 

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

