### PR TITLE
Update OMH schemas to IEEE 1752.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The above code will produce the following JSON in conformance with Open mHealth'
 
 ## Supported Types
 
-|HKQuantityType|Supported|Open mHealth schema|
+|HKQuantityType|Supported|Open mHealth / IEEE 1752 schema|
 |-------------|:---------:|-------------|
 | HKQuantityTypeIdentifierBodyTemperature | :white_check_mark: | [omh:body-temperature:3.x](http://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_body-temperature) |
 | HKCorrelationTypeIdentifierBloodPressure | :white_check_mark: | [omh:blood-pressure:3.x](http://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_blood-pressure) |

--- a/Sources/HealthKitOnOMH/HealthKit Extensions/HKQuantitySample+OMH.swift
+++ b/Sources/HealthKitOnOMH/HealthKit Extensions/HKQuantitySample+OMH.swift
@@ -114,8 +114,8 @@ extension HKQuantitySample {
     private func createTypedDataPoint<T: Schema>(_ body: T) -> any DataPoint {
         SchemaDataPoint<T>(
             header: Header(
-                id: self.uuid.uuidString,
-                creationDateTime: DateTime(date: Date()),
+                uuid: self.uuid.uuidString,
+                sourceCreationDateTime: DateTime(date: Date()),
                 schemaId: type(of: body).schemaId
             ),
             body: body

--- a/Sources/OMHModels/BodyPosture.swift
+++ b/Sources/OMHModels/BodyPosture.swift
@@ -9,7 +9,7 @@ import Foundation
 
 
 /// Set of allowable values describing the posture of the body (e.g., during a measurement).
-/// Generated from Open mHealth `omh:body-posture:1.0` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_body-posture)
+/// Generated from IEEE 1752.1 `body-posture:1.0` (https://w3id.org/ieee/ieee-1752-schema/body-posture.json)
 public enum BodyPosture: String, Schema {
     case sitting
     case lyingDown = "lying down"

--- a/Sources/OMHModels/DataPoint.swift
+++ b/Sources/OMHModels/DataPoint.swift
@@ -6,8 +6,8 @@
 // SPDX-License-Identifier: MIT
 
 
-/// A protocol for an Open mHealth data point container
-/// Generated from Open mHealth `omh:data-point:1.0` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_data-point)
+/// A protocol for an IEEE 1752 data point
+/// Generated from IEEE 1752.1 `data-point-1.0` (https://w3id.org/ieee/ieee-1752-schema/data-point.json)
 public protocol DataPoint<Body>: Sendable, Codable {
     associatedtype Body: Schema
     

--- a/Sources/OMHModels/DateTime.swift
+++ b/Sources/OMHModels/DateTime.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 
-/// Generated from Open mHealth `omh:date-time:1.0` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_date-time)
+/// Generated from IEEE 1752.1 `date-time-1.0` (https://w3id.org/ieee/ieee-1752-schema/date-time.json)
 public struct DateTime: Schema, Equatable {
     /// The Open mHealth schema identifier
-    public static let schemaId = SchemaId(namespace: .omh, name: "date-time", version: "1.0")
+    public static let schemaId = SchemaId(namespace: .ieee, name: "date-time", version: "1.0")
     
     private static let formatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()

--- a/Sources/OMHModels/DescriptiveStatistic.swift
+++ b/Sources/OMHModels/DescriptiveStatistic.swift
@@ -7,6 +7,7 @@
 
 
 /// An enumeration representing different types of statistical measures that can be represented in data points
+/// Generated from IEEE 1752.1 `descriptive-statistic-1.0` (https://w3id.org/ieee/ieee-1752-schema/descriptive-statistic.json)
 public enum DescriptiveStatistic: String, Schema {
     case average
     case count
@@ -27,5 +28,5 @@ public enum DescriptiveStatistic: String, Schema {
     case fourthQuintile = "4th quintile"
     
     /// The Open mHealth schema identifier
-    public static let schemaId = SchemaId(namespace: .omh, name: "descriptive-statistic", version: "1.0")
+    public static let schemaId = SchemaId(namespace: .ieee, name: "descriptive-statistic", version: "1.0")
 }

--- a/Sources/OMHModels/DurationUnitValue.swift
+++ b/Sources/OMHModels/DurationUnitValue.swift
@@ -10,15 +10,4 @@ import Foundation
 
 
 /// Generated from IEEE 1752.1 `duration-unit-value:1.0` (https://w3id.org/ieee/ieee-1752-schema/duration-unit-value.json)
-public struct DurationUnitValue: Schema, Equatable {
-    /// The Open mHealth schema identifier
-    public static let schemaId = SchemaId(namespace: .ieee, name: "duration-unit-value", version: "1.0")
-    
-    public var unit: TimeUnit
-    public var value: Double
-
-    public static func == (lhs: DurationUnitValue, rhs: DurationUnitValue) -> Bool {
-        lhs.unit == rhs.unit &&
-        lhs.value == rhs.value
-    }
-}
+public typealias DurationUnitValue = TypedUnitValue<TimeUnit>

--- a/Sources/OMHModels/DurationUnitValue.swift
+++ b/Sources/OMHModels/DurationUnitValue.swift
@@ -9,10 +9,10 @@
 import Foundation
 
 
-/// Generated from Open mHealth `omh:duration-unit-value:1.0` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_duration-unit-value)
+/// Generated from IEEE 1752.1 `duration-unit-value:1.0` (https://w3id.org/ieee/ieee-1752-schema/duration-unit-value.json)
 public struct DurationUnitValue: Schema, Equatable {
     /// The Open mHealth schema identifier
-    public static let schemaId = SchemaId(namespace: .omh, name: "duration-unit-value", version: "1.0")
+    public static let schemaId = SchemaId(namespace: .ieee, name: "duration-unit-value", version: "1.0")
     
     public var unit: TimeUnit
     public var value: Double

--- a/Sources/OMHModels/DurationUnitValueRange.swift
+++ b/Sources/OMHModels/DurationUnitValueRange.swift
@@ -1,0 +1,18 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+
+/// Generated from IEEE 1752.1 `duration-unit-value-range:1.0` (https://w3id.org/ieee/ieee-1752-schema/duration-unit-value-range.json)
+public struct DurationUnitValueRange: Schema, Equatable {
+    /// The Open mHealth schema identifier
+    public static let schemaId = SchemaId(namespace: .ieee, name: "duration-unit-value-range", version: "1.0")
+    
+    public var unit: TimeUnit
+    public var value: Double
+}

--- a/Sources/OMHModels/ExternalDataSheets.swift
+++ b/Sources/OMHModels/ExternalDataSheets.swift
@@ -9,7 +9,7 @@ import Foundation
 
 
 /// Reference(s) to external documentation regarding the component(s) relevant to describe the collection, computation, use, etc. of this datapoint or data series, e.g., software, algorithm, study protocol, etc.
-public struct ExternalDataSheet: Codable, Sendable {
+public struct ExternalDataSheet: Codable, Sendable, Equatable {
     /// The type of component described or documented by the referenced datasheet, e.g., software, hardware, study.
     public var datasheetType: String?
     

--- a/Sources/OMHModels/ExternalDataSheets.swift
+++ b/Sources/OMHModels/ExternalDataSheets.swift
@@ -17,6 +17,8 @@ public struct ExternalDataSheet: Codable, Sendable {
     public var datasheetReference: String
     
     
+    // swiftlint:disable function_default_parameter_at_end
+    // We disable this rule because the parameter order is based on the schema.
     public init(
         datasheetType: String? = nil,
         datasheetReference: String

--- a/Sources/OMHModels/ExternalDataSheets.swift
+++ b/Sources/OMHModels/ExternalDataSheets.swift
@@ -1,0 +1,27 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+
+/// Reference(s) to external documentation regarding the component(s) relevant to describe the collection, computation, use, etc. of this datapoint or data series, e.g., software, algorithm, study protocol, etc.
+public struct ExternalDataSheet: Codable, Sendable {
+    /// The type of component described or documented by the referenced datasheet, e.g., software, hardware, study.
+    public var datasheetType: String?
+    
+    /// International Resource Identifier (IRI) of applicable datasheet(s). The expectation is that the IRI will convey resolvable location and access information for the resource identified resource.
+    public var datasheetReference: String
+    
+    
+    public init(
+        datasheetType: String? = nil,
+        datasheetReference: String
+    ) {
+        self.datasheetType = datasheetType
+        self.datasheetReference = datasheetReference
+    }
+}

--- a/Sources/OMHModels/FrequencyUnitValue.swift
+++ b/Sources/OMHModels/FrequencyUnitValue.swift
@@ -10,7 +10,7 @@ import Foundation
 
 
 /// Generated from IEEE 1752.1 `frequency-unit-value:1.0` (https://w3id.org/ieee/ieee-1752-schema/frequency-unit-value.json)
-public struct FrequencyUnitValue: Schema {
+public struct FrequencyUnitValue: Schema, Equatable {
     /// The IEEE schema identifier
     public static let schemaId = SchemaId(namespace: .ieee, name: "frequency-unit-value", version: "1.0")
     

--- a/Sources/OMHModels/FrequencyUnitValue.swift
+++ b/Sources/OMHModels/FrequencyUnitValue.swift
@@ -1,0 +1,22 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+/// Generated from IEEE 1752.1 `frequency-unit-value:1.0` (https://w3id.org/ieee/ieee-1752-schema/frequency-unit-value.json)
+public struct FrequencyUnitValue: Schema {
+    /// The IEEE schema identifier
+    public static let schemaId = SchemaId(namespace: .ieee, name: "frequency-unit-value", version: "1.0")
+    
+    /// Time window in which the event occurs or should occur: e.g., in twice a day every other day
+    public var timeWindow: DurationUnitValue
+    
+    /// How many times the event occurs or should occur in the time window
+    public var numberOfTimes: Int
+}

--- a/Sources/OMHModels/Header.swift
+++ b/Sources/OMHModels/Header.swift
@@ -29,7 +29,8 @@ public struct Header: Codable, Sendable {
     /// References to external documentation
     public var externalDatasheets: [ExternalDataSheet]
 
-    
+    // swiftlint:disable function_default_parameter_at_end
+    // We disable this rule because the parameter order is based on the schema.
     public init (
         uuid: String = UUID().uuidString,
         sourceCreationDateTime: DateTime,

--- a/Sources/OMHModels/Header.swift
+++ b/Sources/OMHModels/Header.swift
@@ -8,36 +8,41 @@
 import Foundation
 
 
-/// This schema represents the header of a data point.
-/// Generated from Open mHealth `omh:header:1.2` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_header)
+/// This schema represents the header of a data point or data series.
+/// Generated from IEEE 1752.1 `header-1.0` (https://w3id.org/ieee/ieee-1752-schema/header.json)
 public struct Header: Codable, Sendable {
     /// The identifier of this data point - should be a globally unique value.
-    public var id: String
-
-    /// The date time this data point was created on the system where data is stored.
-    public var creationDateTime: DateTime
+    public var uuid: String
 
     /// The schema identifier of the body of the data point.
     public var schemaId: SchemaId
-
-    /// An `AcquisitionProvenance` provides metadata regarding the origin of the data
-    public var acquisitionProvenance: AcquisitionProvenance?
-
-    /// The user this data point belongs to.
-    public var userId: String?
+    
+    /// The date time this data point was created on the system where data is stored.
+    public var sourceCreationDateTime: DateTime
+    
+    /// The modality whereby the measure is obtained.
+    public var modality: Modality?
+    
+    /// The rate at which measures are acquired.
+    public var acquisitionRate: FrequencyUnitValue?
+    
+    /// References to external documentation
+    public var externalDatasheets: [ExternalDataSheet]
 
     
     public init (
-        id: String,
-        creationDateTime: DateTime,
+        uuid: String = UUID().uuidString,
+        sourceCreationDateTime: DateTime,
         schemaId: SchemaId,
-        acquisitionProvenance: AcquisitionProvenance? = nil,
-        userId: String? = nil
+        modality: Modality? = nil,
+        acquisitionRate: FrequencyUnitValue? = nil,
+        externalDatasheets: [ExternalDataSheet] = []
     ) {
-        self.id = id
-        self.creationDateTime = creationDateTime
+        self.uuid = uuid
+        self.sourceCreationDateTime = sourceCreationDateTime
         self.schemaId = schemaId
-        self.acquisitionProvenance = acquisitionProvenance
-        self.userId = userId
+        self.modality = modality
+        self.acquisitionRate = acquisitionRate
+        self.externalDatasheets = externalDatasheets
     }
 }

--- a/Sources/OMHModels/LengthUnit.swift
+++ b/Sources/OMHModels/LengthUnit.swift
@@ -9,6 +9,7 @@ import Foundation
 
 
 /// A type representing a value paired with a unit specific to length measurements
+/// Generated from IEEE 1752.1 `length-unit-value-1.0` (https://w3id.org/ieee/ieee-1752-schema/length-unit-value.json)
 public typealias LengthUnitValue = TypedUnitValue<LengthUnit>
 
 public enum LengthUnit: String, UnitProtocol {

--- a/Sources/OMHModels/SchemaId.swift
+++ b/Sources/OMHModels/SchemaId.swift
@@ -32,9 +32,8 @@ public struct SchemaId: Sendable, Codable, Equatable {
     }
     
     public static func == (lhs: SchemaId, rhs: SchemaId) -> Bool {
-        return lhs.namespace == rhs.namespace &&
-               lhs.name == rhs.name &&
-               lhs.version == rhs.version
+        lhs.namespace == rhs.namespace &&
+        lhs.name == rhs.name &&
+        lhs.version == rhs.version
     }
 }
-

--- a/Sources/OMHModels/SchemaId.swift
+++ b/Sources/OMHModels/SchemaId.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 
-/// A schema identifier for an Open mHealth schema
-/// Generated from Open mHealth `omh:schema-id:1.1` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_schema-id)
-public struct SchemaId: Sendable, Codable, CustomStringConvertible {
+/// A schema identifier
+/// Generated from IEEE 1752.1`schema-id-1.0` (https://w3id.org/ieee/ieee-1752-schema/schema-id.json)
+public struct SchemaId: Sendable, Codable {
     /// The namespace of the schema. A namespace serves to disambiguate schemas with conflicting names.
     public var namespace: SchemaNamespace
 
@@ -19,14 +19,6 @@ public struct SchemaId: Sendable, Codable, CustomStringConvertible {
 
     /// The version of the schema.
     public var version: String
-
-    /// A URL to retrieve the schema. If a URL is not specified, it is assumed that the schema can be located using other means.
-    public var url: URL?
-    
-    
-    public var description: String {
-        "\(namespace.rawValue):\(name):\(version))"
-    }
     
     
     public init (

--- a/Sources/OMHModels/SchemaId.swift
+++ b/Sources/OMHModels/SchemaId.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// A schema identifier
 /// Generated from IEEE 1752.1`schema-id-1.0` (https://w3id.org/ieee/ieee-1752-schema/schema-id.json)
-public struct SchemaId: Sendable, Codable {
+public struct SchemaId: Sendable, Codable, Equatable {
     /// The namespace of the schema. A namespace serves to disambiguate schemas with conflicting names.
     public var namespace: SchemaNamespace
 
@@ -30,4 +30,11 @@ public struct SchemaId: Sendable, Codable {
         self.name = name
         self.version = version
     }
+    
+    public static func == (lhs: SchemaId, rhs: SchemaId) -> Bool {
+        return lhs.namespace == rhs.namespace &&
+               lhs.name == rhs.name &&
+               lhs.version == rhs.version
+    }
 }
+

--- a/Sources/OMHModels/TemperatureUnit.swift
+++ b/Sources/OMHModels/TemperatureUnit.swift
@@ -9,8 +9,10 @@ import Foundation
 
 
 /// A type representing a value paired with a unit specific to temperature measurements
+/// Generated from IEEE 1752.1 `temperature-unit-value` (https://w3id.org/ieee/ieee-1752-schema/temperature-unit-value.json)
 public typealias TemperatureUnitValue = TypedUnitValue<TemperatureUnit>
 
+/// Allowed values are drawn from the Temperature Units Common Synonyms (non-UCUM). The valid UCUM code is different for Celsius (C) and Fahrenheit ([degF]). (http://download.hl7.de/documents/ucum/ucumdata.html)
 public enum TemperatureUnit: String, UnitProtocol {
     // swiftlint:disable identifier_name
     // We disable this rule because we must use case names as defined by Open mHealth.

--- a/Sources/OMHModels/TimeFrame.swift
+++ b/Sources/OMHModels/TimeFrame.swift
@@ -10,7 +10,7 @@ import Foundation
 
 
 /// Enables a particular time frame to be described as either a point in time or a time interval.
-/// Generated from Open mHealth `omh:time-frame:1.0` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_time-frame)
+/// Generated from IEEE 1752.1 `time-frame-1.0` (https://w3id.org/ieee/ieee-1752-schema/time-frame.json)
 public struct TimeFrame: Schema, Equatable {
     enum CodingKeys: String, CodingKey {
         case dateTime = "date_time"
@@ -18,7 +18,7 @@ public struct TimeFrame: Schema, Equatable {
     }
 
     /// The Open mHealth schema identifier
-    public static let schemaId = SchemaId(namespace: .omh, name: "time-frame", version: "1.0")
+    public static let schemaId = SchemaId(namespace: .ieee, name: "time-frame", version: "1.0")
     public let dateTime: DateTime?
     public let timeInterval: TimeInterval?
 

--- a/Sources/OMHModels/TimeInterval.swift
+++ b/Sources/OMHModels/TimeInterval.swift
@@ -10,10 +10,10 @@ import Foundation
 
 
 /// This schema describes an interval of time. In the absence of a precise start and/or end time, the time interval can be described as a date + a part of the day (morning, afternoon, evening, night). No commitments are made as to whether the start or end time point itself is included in the interval (i.e., whether the defined interval includes the boundary point(s) or not).
-/// Generated from Open mHealth `omh:time-interval:1.0` (https://www.openmhealth.org/documentation/#/schema-docs/schema-library/schemas/omh_time-interval)
+/// Generated from IEEE 1752.1 `time-interval-1.0` (https://w3id.org/ieee/ieee-1752-schema/time-interval.json)
 public struct TimeInterval: Schema, Equatable {
     /// The Open mHealth schema identifier
-    public static let schemaId = SchemaId(namespace: .omh, name: "time-interval", version: "1.0")
+    public static let schemaId = SchemaId(namespace: .ieee, name: "time-interval", version: "1.0")
     
     public var startDateTime: DateTime?
     public var endDateTime: DateTime?

--- a/Sources/OMHModels/TimeUnit.swift
+++ b/Sources/OMHModels/TimeUnit.swift
@@ -10,7 +10,7 @@ import Foundation
 
 
 /// Allowed time units are drawn from the HL7 UCUM Common Synonyms code set (https://download.hl7.de/documents/ucum/ucumdata.html)
-public enum TimeUnit: String, Codable, Sendable {
+public enum TimeUnit: String, UnitProtocol {
     // swiftlint:disable identifier_name
     // We disable this rule because we must use case names as defined by Open mHealth.
     case ps

--- a/Sources/OMHModels/TimeWindow.swift
+++ b/Sources/OMHModels/TimeWindow.swift
@@ -8,9 +8,10 @@
 import Foundation
 
 
-public enum TimeWindow: Codable {
+public enum TimeWindow: Codable, Equatable {
     case duration(DurationUnitValue)
     case durationRange(DurationUnitValueRange)
+    
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
@@ -20,6 +21,17 @@ public enum TimeWindow: Codable {
             self = .durationRange(durationRange)
         } else {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "Mismatched Types")
+        }
+    }
+    
+    public static func == (lhs: TimeWindow, rhs: TimeWindow) -> Bool {
+        switch (lhs, rhs) {
+        case let (.duration(lhsDuration), .duration(rhsDuration)):
+            return lhsDuration == rhsDuration
+        case let (.durationRange(lhsRange), .durationRange(rhsRange)):
+            return lhsRange == rhsRange
+        default:
+            return false
         }
     }
     

--- a/Sources/OMHModels/TimeWindow.swift
+++ b/Sources/OMHModels/TimeWindow.swift
@@ -1,0 +1,35 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+
+public enum TimeWindow: Codable {
+    case duration(DurationUnitValue)
+    case durationRange(DurationUnitValueRange)
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let duration = try? container.decode(DurationUnitValue.self) {
+            self = .duration(duration)
+        } else if let durationRange = try? container.decode(DurationUnitValueRange.self) {
+            self = .durationRange(durationRange)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Mismatched Types")
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .duration(let duration):
+            try container.encode(duration)
+        case .durationRange(let durationRange):
+            try container.encode(durationRange)
+        }
+    }
+}

--- a/Sources/OMHModels/TotalSleepTime.swift
+++ b/Sources/OMHModels/TotalSleepTime.swift
@@ -9,7 +9,7 @@ import Foundation
 
 
 /// Total amount of time spent asleep
-/// Generated from Open mHealth `omh:total-sleep-time:1.0` (https://www.openmhealth.org/schemas/omh_total-sleep-time/)
+/// Generated from IEEE 1752.1 `omh:total-sleep-time:1.0` (https://w3id.org/ieee/ieee-1752-schema/total-sleep-time.json)
 public struct TotalSleepTime: Schema {
     /// The Open mHealth schema identifier
     public static let schemaId = SchemaId(namespace: .omh, name: "total-sleep-time", version: "1.0")
@@ -19,6 +19,9 @@ public struct TotalSleepTime: Schema {
     
     /// The time frame corresponding to this measurement
     public var effectiveTimeFrame: TimeFrame
+    
+    // We disable this rule to stay conformant to the schema
+    public var isMainSleep: Bool? // swiftlint:disable:this discouraged_optional_boolean
     
     /// If the value in this data point is a descriptive statistic rather than a single measurement (e.g. minimum, average, median)
     /// this property should contain the specific type of descriptive statistic
@@ -31,11 +34,13 @@ public struct TotalSleepTime: Schema {
     public init(
         totalSleepTime: DurationUnitValue,
         effectiveTimeFrame: TimeFrame,
+        isMainSleep: Bool? = nil, // swiftlint:disable:this discouraged_optional_boolean
         descriptiveStatistic: DescriptiveStatistic? = nil,
         descriptiveStatisticDenominator: DescriptiveStatisticDenominator? = nil
     ) {
         self.totalSleepTime = totalSleepTime
         self.effectiveTimeFrame = effectiveTimeFrame
+        self.isMainSleep = isMainSleep
         self.descriptiveStatistic = descriptiveStatistic
         self.descriptiveStatisticDenominator = descriptiveStatisticDenominator
     }

--- a/Sources/OMHModels/TypedUnitValue.swift
+++ b/Sources/OMHModels/TypedUnitValue.swift
@@ -21,6 +21,7 @@ public struct TypedUnitValue<T: UnitProtocol>: Codable, Sendable {
     public var unit: T
     public var value: Double
 
+    
     public init(unit: T, value: Double) {
         self.unit = unit
         self.value = value

--- a/Sources/OMHModels/TypedUnitValue.swift
+++ b/Sources/OMHModels/TypedUnitValue.swift
@@ -11,6 +11,8 @@ import Foundation
 public protocol UnitProtocol: Codable, Sendable {
 }
 
+/// A numerical value with a unit of measure
+/// Generated from IEEE 1752.1 `unit-value-1.0` (https://w3id.org/ieee/ieee-1752-schema/unit-value.json)
 public struct TypedUnitValue<T: UnitProtocol>: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case unit, value

--- a/Sources/OMHModels/TypedUnitValue.swift
+++ b/Sources/OMHModels/TypedUnitValue.swift
@@ -8,9 +8,6 @@
 import Foundation
 
 
-public protocol UnitProtocol: Codable, Sendable {
-}
-
 /// A numerical value with a unit of measure
 /// Generated from IEEE 1752.1 `unit-value-1.0` (https://w3id.org/ieee/ieee-1752-schema/unit-value.json)
 public struct TypedUnitValue<T: UnitProtocol>: Codable, Sendable {

--- a/Sources/OMHModels/TypedUnitValueRange.swift
+++ b/Sources/OMHModels/TypedUnitValueRange.swift
@@ -1,0 +1,53 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+
+/// This schema represents a range of numerical values with a unit of measure.
+/// Generated from IEEE 1752.1 `unit-value-range-1.0` (https://w3id.org/ieee/ieee-1752-schema/unit-value-range.json)
+public struct TypedUnitValueRange<T: UnitProtocol>: Codable, Sendable {
+    private enum CodingKeys: String, CodingKey {
+        case unit, lowValue, highValue
+    }
+    
+    public var unit: T
+    public var lowValue: Double
+    public var highValue: Double
+    
+    
+    public init(unit: T, lowValue: Double, highValue: Double) {
+        self.unit = unit
+        self.lowValue = lowValue
+        self.highValue = highValue
+    }
+    
+    public init(unit: T, lowValue: Int, highValue: Int) {
+        self.unit = unit
+        self.lowValue = Double(lowValue)
+        self.highValue = Double(highValue)
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        unit = try container.decode(T.self, forKey: .unit)
+        lowValue = try container.decode(Double.self, forKey: .lowValue)
+        highValue = try container.decode(Double.self, forKey: .highValue)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(unit, forKey: .unit)
+        try container.encode(lowValue, forKey: .lowValue)
+        try container.encode(highValue, forKey: .highValue)
+    }
+}
+
+extension TypedUnitValueRange: Equatable where T: Equatable {
+    public static func == (lhs: TypedUnitValueRange<T>, rhs: TypedUnitValueRange<T>) -> Bool {
+        lhs.unit == rhs.unit &&
+        lhs.lowValue == rhs.lowValue &&
+        lhs.highValue == rhs.highValue
+    }
+}

--- a/Sources/OMHModels/UnitProtocol.swift
+++ b/Sources/OMHModels/UnitProtocol.swift
@@ -5,8 +5,9 @@
 //
 // SPDX-License-Identifier: MIT
 
+
 import Foundation
 
 
-/// Generated from IEEE 1752.1 `duration-unit-value-range:1.0` (https://w3id.org/ieee/ieee-1752-schema/duration-unit-value-range.json)
-public typealias DurationUnitValueRange = TypedUnitValueRange<TimeUnit>
+public protocol UnitProtocol: Codable, Sendable {
+}

--- a/Tests/OMHModelsTests/HeaderTests.swift
+++ b/Tests/OMHModelsTests/HeaderTests.swift
@@ -1,0 +1,65 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+@testable import OMHModels
+
+class HeaderTests: XCTestCase {
+    func testDefaultInit() {
+        let dateTime = DateTime(date: .now)
+        let schemaId = SchemaId(
+            namespace: .ieee,
+            name: "test-schema",
+            version: "1.0"
+        )
+        
+        let header = Header(sourceCreationDateTime: dateTime, schemaId: schemaId)
+        
+        XCTAssertNotNil(header.uuid)
+        XCTAssertEqual(header.sourceCreationDateTime, dateTime)
+        XCTAssertEqual(header.schemaId, schemaId)
+        XCTAssertNil(header.modality)
+        XCTAssertNil(header.acquisitionRate)
+        XCTAssertTrue(header.externalDatasheets.isEmpty)
+    }
+    
+    func testFullInit() {
+        let uuid = UUID().uuidString
+        let dateTime = DateTime(date: .now)
+        let schemaId = SchemaId(
+            namespace: .ieee,
+            name: "test-schema",
+            version: "1.0"
+        )
+        let modality = Modality.selfReported
+        let acquisitionRate = FrequencyUnitValue(
+            timeWindow: DurationUnitValue(
+                unit: TimeUnit.h,
+                value: 1
+            ),
+            numberOfTimes: 10
+        )
+        let externalDatasheet = ExternalDataSheet(datasheetReference: "reference")
+        
+        let header = Header(
+            uuid: uuid,
+            sourceCreationDateTime: dateTime,
+            schemaId: schemaId,
+            modality: modality,
+            acquisitionRate: acquisitionRate,
+            externalDatasheets: [externalDatasheet]
+        )
+        
+        XCTAssertEqual(header.uuid, uuid)
+        XCTAssertEqual(header.sourceCreationDateTime, dateTime)
+        XCTAssertEqual(header.schemaId, schemaId)
+        XCTAssertEqual(header.modality, modality)
+        XCTAssertEqual(header.acquisitionRate, acquisitionRate)
+        XCTAssertEqual(header.externalDatasheets, [externalDatasheet])
+    }
+}

--- a/Tests/OMHModelsTests/HeaderTests.swift
+++ b/Tests/OMHModelsTests/HeaderTests.swift
@@ -6,8 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-import XCTest
 @testable import OMHModels
+import XCTest
 
 class HeaderTests: XCTestCase {
     func testDefaultInit() {

--- a/Tests/OMHModelsTests/TimeWindowTests.swift
+++ b/Tests/OMHModelsTests/TimeWindowTests.swift
@@ -1,0 +1,47 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@testable import OMHModels
+import XCTest
+
+
+class TimeWindowTests: XCTestCase {
+    func testEncodeAndDecodeDuration() throws {
+        let originalValue = TimeWindow.duration(
+            TypedUnitValue(
+                unit: .sec,
+                value: 30.0
+            )
+        )
+        
+        let data = try JSONEncoder().encode(originalValue)
+        let decodedValue = try JSONDecoder().decode(TimeWindow.self, from: data)
+        
+        XCTAssertEqual(originalValue, decodedValue)
+    }
+
+    func testEncodeAndDecodeDurationRange() throws {
+        let originalValue = TimeWindow.durationRange(
+            TypedUnitValueRange(
+                unit: .min,
+                lowValue: 10.0,
+                highValue: 30.0
+            )
+        )
+        
+        let data = try JSONEncoder().encode(originalValue)
+        let decodedValue = try JSONDecoder().decode(TimeWindow.self, from: data)
+        
+        XCTAssertEqual(originalValue, decodedValue)
+    }
+
+    func testDecodeInvalidData() throws {
+        let invalidData = try XCTUnwrap("Invalid Data".data(using: .utf8))
+        XCTAssertThrowsError(try JSONDecoder().decode(TimeWindow.self, from: invalidData))
+    }
+}

--- a/Tests/OMHModelsTests/TypedUnitValueRangeTests.swift
+++ b/Tests/OMHModelsTests/TypedUnitValueRangeTests.swift
@@ -1,0 +1,49 @@
+//
+// This source file is part of the HealthKitOnOMH open source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@testable import OMHModels
+import XCTest
+
+
+final class TypedUnitValueRangeTests: XCTestCase {
+    // Dummy unit for testing
+    struct TestUnit: UnitProtocol, Equatable {
+        var name: String
+    }
+    
+    func testInitialization() {
+        let range = TypedUnitValueRange(unit: TestUnit(name: "TestUnit1"), lowValue: 10.0, highValue: 20.0)
+        XCTAssertEqual(range.unit, TestUnit(name: "TestUnit1"))
+        XCTAssertEqual(range.lowValue, 10.0)
+        XCTAssertEqual(range.highValue, 20.0)
+    }
+    
+    func testInitializationWithIntegers() {
+        let range = TypedUnitValueRange(unit: TestUnit(name: "TestUnit2"), lowValue: 10, highValue: 20)
+        XCTAssertEqual(range.unit, TestUnit(name: "TestUnit2"))
+        XCTAssertEqual(range.lowValue, 10.0)
+        XCTAssertEqual(range.highValue, 20.0)
+    }
+    
+    func testEquatable() {
+        let range1 = TypedUnitValueRange(unit: TestUnit(name: "TestUnit3"), lowValue: 10, highValue: 20)
+        let range2 = TypedUnitValueRange(unit: TestUnit(name: "TestUnit3"), lowValue: 10, highValue: 20)
+        let range3 = TypedUnitValueRange(unit: TestUnit(name: "TestUnit3"), lowValue: 15, highValue: 25)
+        
+        XCTAssertEqual(range1, range2)
+        XCTAssertNotEqual(range1, range3)
+    }
+    
+    func testEncodingAndDecoding() throws {
+        let range = TypedUnitValueRange(unit: TestUnit(name: "TestUnit4"), lowValue: 10, highValue: 20)
+        let encodedData = try JSONEncoder().encode(range)
+        let decodedRange = try JSONDecoder().decode(TypedUnitValueRange<TestUnit>.self, from: encodedData)
+        
+        XCTAssertEqual(range, decodedRange)
+    }
+}


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign Digital Health Group open-source organization

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Update OMH schemas to IEEE 1752.1

This PR updates schemas that have been published as part of [IEEE Standard 1752.1's open-source repository](https://opensource.ieee.org/omh/1752/)

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

